### PR TITLE
Remove colon in subtitle

### DIFF
--- a/_posts/2019-12-11-5th-workshop-announcement.md
+++ b/_posts/2019-12-11-5th-workshop-announcement.md
@@ -7,7 +7,7 @@ date: 2019-12-11T00:00:00
 tags: workshop
 ---
 
-[POSTPONED!](https://oggm.org/2020/05/12/5th-workshop-postponed/)
+**Due to the situation, the workshop is POSTPONED! Visit [this link]({{site.base_url}}/2020/05/12/5th-workshop-postponed/) for the new announcement.**
 
 The 5th OGGM workshop will take place from June 8th to 12th in Neuharlingersiel, Germany.
 
@@ -19,57 +19,57 @@ of the [OGGM](http://docs.oggm.org) model. The workshop is open to any intereste
 
 ### Save the date
 
-**Monday 8th to Friday 12th of June 2020**. Monday to Wednesday the focus will be on presentations of previous and 
-ongoing work, Thursday to Friday will focus on trainings and coding sessions (hands-on). 
+**Monday 8th to Friday 12th of June 2020**. Monday to Wednesday the focus will be on presentations of previous and
+ongoing work, Thursday to Friday will focus on trainings and coding sessions (hands-on).
 We will start in the late afternoon on Monday, and finish before noon on Friday.
 
 ### Location
 
-The workshop will be held at the DJH (youth hostel with very good standard) Neuharlingersiel 
-([www.djh-resort.de](https://www.djh-resort.de)), 
-very close to the North Sea coast. The hostel provides all facilities for our workshop (incl. catering). 
-The location is best reached by train to Norden, from where we will offer a shuttle. More information on 
+The workshop will be held at the DJH (youth hostel with very good standard) Neuharlingersiel
+([www.djh-resort.de](https://www.djh-resort.de)),
+very close to the North Sea coast. The hostel provides all facilities for our workshop (incl. catering).
+The location is best reached by train to Norden, from where we will offer a shuttle. More information on
 logistics will be provided to registered participants later.
 
 ### Agenda
 
-This tentative schedule is for orientation only. We would like this workshop to be as flexible as possible and will 
-adjust to the needs and suggestions of the participants! **The first part of the workshop (08th to 10th of June)** 
+This tentative schedule is for orientation only. We would like this workshop to be as flexible as possible and will
+adjust to the needs and suggestions of the participants! **The first part of the workshop (08th to 10th of June)**
 has two main objectives:
 
-1. **State and applications of OGGM** : the first sessions will deal with presentations from the participants about 
+1. **State and applications of OGGM** : the first sessions will deal with presentations from the participants about
 the state, recent developments and results of OGGM, and its place in the international context of glacier modeling.
 
-2. **Future developments and visions for OGGM** : the second session will be dedicated to specific discussions and 
+2. **Future developments and visions for OGGM** : the second session will be dedicated to specific discussions and
 more general brainstorming about the future and goals of the OGGM project.
-    
+
 **For the hands-on sessions in the following two days**, we will split the participants into smaller groups:
 
-- **Beginner tutorials**: these sessions are for current and future OGGM users to get to know the model internals 
+- **Beginner tutorials**: these sessions are for current and future OGGM users to get to know the model internals
   and learn how to set-up and customize a model run.
 - **Code sprints**: we will address specific coding challenges
   together, in the form of a [programming sprint](https://oggm.org/2018/10/16/hack-day/).
 - **Q&A**: we will leave time open to discuss actual problems in the model itself,
   and try to develop strategies to solve them.
-    
-This second part is targeting current and future model *users*, or 
+
+This second part is targeting current and future model *users*, or
 people interested in the model internals. It will be rather technical.
 
 ### Who can participate ?
 
-Anyone interested in the model, or in glaciological modeling in general! In particular, we would like to 
-encourage potential users and developers to join us, to get to know each other, and to gather first-hand 
-information about the model internals. 
+Anyone interested in the model, or in glaciological modeling in general! In particular, we would like to
+encourage potential users and developers to join us, to get to know each other, and to gather first-hand
+information about the model internals.
 Note that in case of high interest we might have to limit the number of participants.
 
 ### Workshop fee
 
-**The fee for participation for the entire workshop is € 490**, and includes the costs for the workshop, room (four nights), 
-and full board from the afternoon of June 8th to the morning of June 12. 
+**The fee for participation for the entire workshop is € 490**, and includes the costs for the workshop, room (four nights),
+and full board from the afternoon of June 8th to the morning of June 12.
 
 ### Registration
 
-If you wish to participate to the workshop or if you have questions regarding the organization please send us an 
+If you wish to participate to the workshop or if you have questions regarding the organization please send us an
 e-mail at _info [at] oggm.org_. **Registration closes on March 31st, 2020.**
 
 
@@ -83,4 +83,3 @@ e-mail at _info [at] oggm.org_. **Registration closes on March 31st, 2020.**
 - <u> <a href="{{ site.url }}/2017/04/03/2nd-oggm-worshop-summary/"> 2nd OGGM workshop </a> </u>
 - <u> <a href="{{ site.url }}/2018/06/29/3nd-oggm-worshop-summary/"> 3rd OGGM workshop </a> </u>
 - <u> <a href="{{ site.url }}/2019/06/21/4st-oggm-worshop-summary/"> 4th OGGM workshop </a> </u>
-

--- a/_posts/2020-05-12-5th-workshop-postponed.md
+++ b/_posts/2020-05-12-5th-workshop-postponed.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: 5th OGGM workshop moved to Feb. 2021
-subtitle: new date: 22-26 February 2021 in Neuharlingersiel, Germany
+subtitle: New date! 22-26 February 2021 in Neuharlingersiel, Germany
 author: Jan-Hendrik Malles
 date: 2020-05-12T00:00:00
 tags: workshop
@@ -35,4 +35,3 @@ Otherwise, you will get a refund after contacting us.
 - <u> <a href="{{ site.url }}/2017/04/03/2nd-oggm-worshop-summary/"> 2nd OGGM workshop </a> </u>
 - <u> <a href="{{ site.url }}/2018/06/29/3nd-oggm-worshop-summary/"> 3rd OGGM workshop </a> </u>
 - <u> <a href="{{ site.url }}/2019/06/21/4st-oggm-worshop-summary/"> 4th OGGM workshop </a> </u>
-


### PR DESCRIPTION
cc @jmalles the `:` does not play well in titles because of the md format (I also didn't know) 