### PR TITLE
Update meetings page 

### DIFF
--- a/meetings.html
+++ b/meetings.html
@@ -7,13 +7,21 @@ header-img: "img/backgrounds/members.jpg"
 
 <h3>OGGM Open Calls</h3>
 
-<p>OGGM holds check-in meetings every second Wednesday. The meetings
-are held on Slack (<a href="mailto:info@oggm.org">reach out</a> if you want
-to join in). These meetings are open to anyone!</p>
+<p>There are two types of open meetings we have regularly have on-line within the OGGM community. 
+We hold check-in meetings every second Wednesday. These meetings are held on Slack 
+(<a href="mailto:info@oggm.org">reach out</a> if you want
+to join in). The check-in meetings are a good place to keep up to date of what’s happening, ask 
+questions and discuss work in progress. In addition on the other Wednesdays we have started the 
+OGGM “Science Café”. The science café is a meeting were we can have a discussion on a specific topic 
+(e.g. discuss an article) or have a (invited) presentation on a topic that is relevant to the community. 
+Both these meetings are open to anyone!</p>
 
-<p>Currently the meeting is at 16:00 CET/CEST, but we can change this to accommodate for
+<p>Currently the meetings are at 16:00 CET/CEST, but we can change this to accommodate for
 other time zones. A google calendar has been setup with these regular times
-(<a href="https://calendar.google.com/calendar/embed?src=34b998vus0mcp3k766dl7vulm0%40group.calendar.google.com&ctz=Europe%2FLondon">GCAL</a> / <a href="https://calendar.google.com/calendar/ical/34b998vus0mcp3k766dl7vulm0%40group.calendar.google.com/public/basic.ics">ICAL</a>):</p>
+(<a href="https://calendar.google.com/calendar/embed?src=34b998vus0mcp3k766dl7vulm0%40group.calendar.google.com&ctz=Europe%2FLondon">GCAL</a> / <a href="https://calendar.google.com/calendar/ical/34b998vus0mcp3k766dl7vulm0%40group.calendar.google.com/public/basic.ics">ICAL</a>).
+The OGGM “Science Cafés” only take place when there is content, so suggestions are very much welcome. 
+If the status remains “Open Time Slot”, the meeting is not happening on that specific date. For more info about 
+the content of a specific science cafe, click on the meeting in the calendar bellow:</p>
 
 <p>
 <iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=suggestion%3AEurope%2FVienna&amp;src=MzRiOTk4dnVzMG1jcDNrNzY2ZGw3dnVsbTBAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%233F51B5&amp;mode=AGENDA&amp;showPrint=0&amp;showTabs=0&amp;showNav=0&amp;showDate=0&amp;showTz=1" style="border-width:0" width="100%" height="300" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Here follows a suggestion for an update of the text on the oggm.org/meetings page.

Contact details for the  OGGM "Science Café" are still missing. Shall we put the info@oggm.org for those that are not on Slack?