### PR TITLE
Removing twitter link from the website footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,16 +12,16 @@
                             </span>
                         </a>
                     </li>
-                    <!-- <p> {% if site.twitter_username %}
-                    <li>
+                    {% if site.twitter_username %}
+                    <!-- <li>
                         <a href="https://twitter.com/{{ site.twitter_username }}">
                             <span class="fa-stack fa-lg">
                                 <i class="fa fa-circle fa-stack-2x"></i>
                                 <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
                             </span>
                         </a>
-                    </li>
-                    {% endif %} </p> -->
+                    </li> -->
+                    {% endif %}
                     {% if site.facebook_username %}
                     <li>
                         <a href="https://www.facebook.com/{{ site.facebook_username }}">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -12,7 +12,7 @@
                             </span>
                         </a>
                     </li>
-                    {% if site.twitter_username %}
+                    <!-- <p> {% if site.twitter_username %}
                     <li>
                         <a href="https://twitter.com/{{ site.twitter_username }}">
                             <span class="fa-stack fa-lg">
@@ -21,7 +21,7 @@
                             </span>
                         </a>
                     </li>
-                    {% endif %}
+                    {% endif %} </p> -->
                     {% if site.facebook_username %}
                     <li>
                         <a href="https://www.facebook.com/{{ site.facebook_username }}">


### PR DESCRIPTION
This PR is meant to address issue #256. 

As there are a couple of blog posts on the website that refer to specific posts on the OGGM twitter, I would suggest to not break those links, but only remove the twitter logo and link from the footer. For now I just thought to comment that part of the code out, but we can also remove it. Either way would be fine with me. 

As I normally don't make changes to the website template, I was wondering, @fmaussion would you be up for having a quick look at this PR? I'm afraid to break something...